### PR TITLE
Enable select controls

### DIFF
--- a/static/ec.js
+++ b/static/ec.js
@@ -59,6 +59,9 @@ var modifyEvent = function(e) {
     // listeners for info radio buttons
     $('#yes-no_block :radio').change(selectRadio);
 
+    // listeners for select drop-downs
+    $('#basicinfo_block select').change(selectRadio);
+
     // listeners for text fields
     // $('#basicinfo_block :date').blur(storeText); // doesn't work in Firefox :(
 

--- a/static/shared.js
+++ b/static/shared.js
@@ -254,6 +254,7 @@ var selectCheckbox = function(e) {
 }
 
 /* Adds or deletes values for each variable based on radio buttons selected. */
+/* Also handles select controls */
 var selectRadio = function(e) {
   var el       = $(e.target);
   var aid      = $(".article").attr("id").split("_")[1];  
@@ -280,7 +281,7 @@ var selectRadio = function(e) {
   });
 
   req.fail(function(e) {
-    $("#flash-error").text("Error changing radio button.");
+    $("#flash-error").text("Error changing radio button or drop-down.");
     $("#flash-error").show();
   });
 }


### PR DESCRIPTION
This one shoehorns in the ability to use select controls in the basic info tab.  I did this by using the same handlers and stuff as are used for radios, but having gotten more familiar with the system since then I notice that select controls are already used in the admin interface, so maybe I should have ported that functionality to the event coding areas rather than piggybacking on the radios?  So if so, feel free to reject this one and let me know that there's an easier way (which I'll then probably use if I use selects on some other tab in the future).