### PR TITLE
Activate article level

### DIFF
--- a/models.py
+++ b/models.py
@@ -8,6 +8,27 @@ from pytz import timezone
 
 central = timezone('US/Central')
 
+class CoderArticleAnnotation(Base):
+    __tablename__ = 'coder_article_annotation'
+    id         = Column(Integer, primary_key=True)
+    article_id = Column(Integer, ForeignKey('article_metadata.id'), nullable = False)
+    variable   = Column(String(100), nullable = False)
+    value      = Column(String(2000), nullable = False)
+    text       = Column(Unicode(2000))
+    coder_id   = Column(Integer, ForeignKey('user.id'))
+    timestamp  = Column(DateTime)
+
+    def __init__(self, article_id, variable, value, coder_id, text = None):
+        self.article_id = article_id
+        self.variable   = variable
+        self.value      = value
+        self.text       = text
+        self.coder_id   = coder_id
+        self.timestamp  = dt.datetime.now(tz = central).replace(tzinfo = None)
+
+    def __repr__(self):
+        return '<CoderArticleAnnotation %r>' % (self.id)
+
 class CodeFirstPass(Base):
     __tablename__ = 'coder_first_pass'
     id         = Column(Integer, primary_key=True)

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -1555,8 +1555,8 @@ def getEvents():
             if len(rvar['desc']) > 0 and len(rvar['desc'][0]) > 0:
                 ev['repr'] = ", ".join(rvar['desc'])
                 ## No longer necessary with article-level description
-            #elif len(rvar['article-desc']) > 0 and len(rvar['article-desc'][0]) > 0:
-                #ev['repr'] = "(no event description): " + ", ".join(rvar['article-desc'])
+            elif len(rvar['article-desc']) > 0 and len(rvar['article-desc'][0]) > 0:
+                ev['repr'] = "(no event description): " + ", ".join(rvar['article-desc'])
             else:
                 ev['repr'] = "(no event description)"
 

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -55,8 +55,10 @@ from sqlite3 import dbapi2 as sqlite3
 
 ## app-specific
 from database import db_session
-from models import ArticleMetadata, ArticleQueue, CodeFirstPass, CodeSecondPass, CodeEventCreator, \
-    Event, EventCreatorQueue, SecondPassQueue, User
+
+from models import ArticleMetadata, ArticleQueue, CoderArticleAnnotation, \
+CodeFirstPass, CodeSecondPass, CodeEventCreator, \
+Event, EventCreatorQueue, SecondPassQueue, User
 
 # create our application
 app = Flask(__name__)
@@ -1166,6 +1168,108 @@ def generateCoderAudit():
 ##### Internal calls
 #####
 
+@app.route('/_add_article_code/<pn>')
+@login_required
+def addArticleCode(pn):
+    """ Adds a record to article coding table. """
+    aid  = int(request.args.get('article'))
+    var  = request.args.get('variable')
+    val  = request.args.get('value')
+    text = request.args.get('text')
+    aqs  = []
+    now  = dt.datetime.now(tz = central).replace(tzinfo = None)
+
+    if pn == 'ec':
+        model = CoderArticleAnnotation
+        p     = CoderArticleAnnotation(aid, var, val, current_user.id, text)
+
+        for aq in db_session.query(EventCreatorQueue).filter_by(article_id = aid, coder_id = current_user.id).all():
+            aq.coded_dt = now
+            aqs.append(aq)
+    else:
+        return make_response("Invalid model", 404)
+
+    ## variables which only have one value per article
+    if var in sv:
+        a = db_session.query(model).filter_by(
+            article_id = aid,
+            variable   = var,
+            coder_id   = current_user.id
+        ).all()
+
+        ## if there's more then one, delete them
+        if len(a) > 0:
+            for o in a:
+                db_session.delete(o);
+
+            db_session.commit()
+
+    db_session.add(p)
+    db_session.add_all(aqs)
+    db_session.commit()
+    return make_response("", 200)
+
+
+@app.route('/_del_article_code/<pn>')
+@login_required
+def delArticleCode(pn):
+    """ Deletes a record from article coding table. """
+    article  = request.args.get('article')
+    variable = request.args.get('variable')
+    value    = request.args.get('value')
+
+    if pn == 'ec':
+        a = db_session.query(CoderArticleAnnotation).filter_by(
+            article_id = article,
+            variable   = variable,
+            value      = value,
+            coder_id   = current_user.id
+        ).all()
+    else:
+        return make_response("Invalid model", 404)
+
+    if len(a) > 0:
+        for o in a:
+            db_session.delete(o)
+
+        db_session.commit()
+
+        return jsonify(result={"status": 200})
+    else:
+        return make_response("", 404)
+
+
+@app.route('/_change_article_code/<pn>')
+@login_required
+def changeArticleCode(pn):
+    """ 
+        Changes a radio button or text input/area by removing all prior
+        values, adds one new one.
+    """
+    article  = request.args.get('article')
+    variable = request.args.get('variable')
+    value    = request.args.get('value')
+
+    ## delete all prior values
+    a = db_session.query(CoderArticleAnnotation).filter_by(
+        article_id = article,
+        variable   = variable,
+        coder_id   = current_user.id
+    ).all()
+
+    for o in a:
+        db_session.delete(o)
+    db_session.commit()
+
+    ## add new value
+    ac = CoderArticleAnnotation(article, variable, value, current_user.id)
+
+    db_session.add(ac)
+    db_session.commit()
+
+    return jsonify(result={"status": 200})
+
+
 @app.route('/_add_code/<pn>')
 @login_required
 def addCode(pn):
@@ -1240,32 +1344,6 @@ def addCode(pn):
     db_session.add_all(aqs)
     db_session.commit()
     return make_response("", 200)
-
-
-@app.route('/_del_event')
-@login_required
-def delEvent():
-    """ Delete an event. """
-    # if current_user.authlevel < 2:
-    #     return redirect(url_for('index'))
-
-    eid = int(request.args.get('event'))
-    pn  = request.args.get('pn');
-
-    model = None
-    if pn == '2':
-        model = CodeSecondPass
-    elif pn == 'ec':
-        model = CodeEventCreator
-    else:
-        return make_response("Invalid model.", 404)
-
-    db_session.query(model).filter_by(event_id = eid).delete()
-    db_session.query(Event).filter_by(id = eid).delete()
-
-    db_session.commit()
-
-    return make_response("Delete succeeded.", 200)
 
 
 @app.route('/_del_code/<pn>')
@@ -1347,6 +1425,32 @@ def changeCode(pn):
     db_session.commit()
 
     return jsonify(result={"status": 200})
+
+
+@app.route('/_del_event')
+@login_required
+def delEvent():
+    """ Delete an event. """
+    # if current_user.authlevel < 2:
+    #     return redirect(url_for('index'))
+
+    eid = int(request.args.get('event'))
+    pn  = request.args.get('pn');
+
+    model = None
+    if pn == '2':
+        model = CodeSecondPass
+    elif pn == 'ec':
+        model = CodeEventCreator
+    else:
+        return make_response("Invalid model.", 404)
+
+    db_session.query(model).filter_by(event_id = eid).delete()
+    db_session.query(Event).filter_by(id = eid).delete()
+
+    db_session.commit()
+
+    return make_response("Delete succeeded.", 200)
 
 
 @app.route('/_mark_ec_done')
@@ -1450,10 +1554,11 @@ def getEvents():
         elif pn =='ec':
             if len(rvar['desc']) > 0 and len(rvar['desc'][0]) > 0:
                 ev['repr'] = ", ".join(rvar['desc'])
-            elif len(rvar['article-desc']) > 0 and len(rvar['article-desc'][0]) > 0:
-                ev['repr'] = "(no event description): " + ", ".join(rvar['article-desc'])
+                ## No longer necessary with article-level description
+            #elif len(rvar['article-desc']) > 0 and len(rvar['article-desc'][0]) > 0:
+                #ev['repr'] = "(no event description): " + ", ".join(rvar['article-desc'])
             else:
-                ev['repr'] = "(no article description)"
+                ev['repr'] = "(no event description)"
 
         evs.append(ev)
 
@@ -1506,6 +1611,37 @@ def getCodes():
 
     return jsonify(cd)
 
+
+@app.route('/_load_article_annotation_block')
+@login_required
+def modifyArticleAnnotations():
+    aid  = int(request.args.get('article_id'))
+    pn   = request.args.get('pn')
+    curr = {}
+
+    model = None
+    if pn == 'ec':
+        model = CoderArticleAnnotation
+        template = 'article-annotation-block.html'
+    else:
+        return make_response("Not a valid model.", 404)
+
+    ## get the current values
+    for annotation in db_session.query(model).filter_by(article_id = aid, coder_id = current_user.id).all():
+        if annotation.variable in sv or annotation.variable in event_creator_single_value:
+            curr[annotation.variable] = annotation.value
+        else:
+            ## stash in array
+            if annotation.variable not in curr:
+                curr[annotation.variable] = []
+
+            ## loads the items which do not have text, which means
+            ## everything but text selects
+            if annotation.text is None:
+                curr[annotation.variable].append(annotation.value)
+
+    return render_template(template, 
+            curr = curr)
 
 @app.route('/_load_event_block')
 @login_required

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -1555,8 +1555,8 @@ def getEvents():
             if len(rvar['desc']) > 0 and len(rvar['desc'][0]) > 0:
                 ev['repr'] = ", ".join(rvar['desc'])
                 ## No longer necessary with article-level description
-            elif len(rvar['article-desc']) > 0 and len(rvar['article-desc'][0]) > 0:
-                ev['repr'] = "(no event description): " + ", ".join(rvar['article-desc'])
+            #elif len(rvar['article-desc']) > 0 and len(rvar['article-desc'][0]) > 0:
+                #ev['repr'] = "(no event description): " + ", ".join(rvar['article-desc'])
             else:
                 ev['repr'] = "(no event description)"
 

--- a/static/ec.js
+++ b/static/ec.js
@@ -1,3 +1,40 @@
+/* Edit article-level info. */
+var modifyArticleAnnotations = function() {
+  var aid  = $(".article").attr("id").split("_")[1];
+  var pn   = $('#pass_number').val();
+
+  req = $.ajax({
+      type: "GET",
+      url:  $SCRIPT_ROOT + '/_load_article_annotation_block',
+      data: {
+        'article_id': aid,
+        'pn': pn
+      }
+  });
+
+  req.done(function() {
+    $("#flash-error").hide();
+
+    // add the article block to the HTML
+    $('#article-annotation-blocks').append(req.responseText);
+
+    // listeners for info radio buttons
+    $('#article-annotation-block :radio').change(selectRadio);
+
+    // listeners for text fields
+    $('#article-annotation-block :text').blur(storeArticleTextInput);
+    $('#article-annotation-block textarea').blur(storeArticleTextInput);
+
+    // listeners for adding or deleting checkboxes
+    $('#article-annotation-block :checkbox').change(selectArticleCheckbox);
+  });
+
+  req.fail(function(e) {
+    $("#flash-error").text("Error loading article annotation block.");
+    $("#flash-error").show();
+  });
+}
+
 /* Add or edit an event. Controls the event list. */
 var modifyEvent = function(e) {
   var aid  = $(".article").attr("id").split("_")[1];
@@ -69,7 +106,9 @@ var modifyEvent = function(e) {
     $('#basicinfo_block textarea').blur(storeText);
 
     // listeners for adding or deleting checkboxes
-    $(':checkbox').change(selectCheckbox);
+    $('#basicinfo_block :checkbox').change(selectCheckbox);
+    $('#yes-no_block :checkbox').change(selectCheckbox);
+    $('#preset_block :checkbox').change(selectCheckbox);
 
     // Get text select vars from DOM  
     $('.varblock').each(function() {
@@ -255,6 +294,9 @@ $(function(){
   // add event listener
   $('#add-event').click(modifyEvent);
 
+  // test code for article block
+  modifyArticleAnnotations()
+
   // mark done handler
   $('#mark-done').each(function() {
     $(this).click(function() {
@@ -280,4 +322,4 @@ $(function(){
     }); 
   });
 
-});    
+});

--- a/static/shared.js
+++ b/static/shared.js
@@ -139,6 +139,7 @@ var deleteCode = function(e) {
 }
 
 /* Adds a value for a variable if not available in the current list. */
+// DS 2020-01-16: Looks like this is only used by code1.js and code2.js
 var addCode = function(e) {
   var oText    = '';
   var aid      = $(".article").attr("id").split("_")[1];
@@ -207,7 +208,51 @@ var generate_handler = function( v, type ) {
   };
 }
 
-/* Adds or deletes values for each variable based on checkboxes. */
+/* Adds or deletes values for article variables based on checkboxes. */
+var selectArticleCheckbox = function(e) {
+  var el       = $(e.target);
+  var aid      = $(".article").attr("id").split("_")[1];  
+  var pn       = $('#pass_number').val();
+
+  var variable = el.attr("id").split("_")[1];
+  var val      = el.val();
+
+  // for some of the basic info variables, id == val. change to 'yes'
+  if (variable == val) {
+    val = 'yes';
+  }
+
+  var is_checked = el.is(':checked');
+  var action = ''
+
+  // add this checkbox item
+  if (is_checked == true) {
+    action = 'add';
+  } else { // delete it
+    action = 'del';
+  }
+
+  req = $.ajax({
+    type: "GET",
+    url:  $SCRIPT_ROOT + '/_' + action + '_article_code/' + pn,
+    data: {
+      article:  aid,
+      variable: variable,
+      value:    val
+    }
+  });
+
+  req.done(function(e) {
+    $('#flash-error').hide();
+  });
+
+  req.fail(function(e) {
+    $("#flash-error").text("Error changing checkbox.");
+    $("#flash-error").show();
+  });
+}
+
+/* Adds or deletes values for each event variable based on checkboxes. */
 var selectCheckbox = function(e) {
   var el       = $(e.target);
   var aid      = $(".article").attr("id").split("_")[1];  
@@ -287,6 +332,38 @@ var selectRadio = function(e) {
 }
 
 /* Adds or deletes values for each variable based on radio buttons selected. */
+var storeArticleTextInput = function(e) {
+  var el       = $(e.target);
+  var aid      = $(".article").attr("id").split("_")[1];  
+//  var eid      = el.closest(".event-block").attr("id").split("_")[1];
+  var pn       = $('#pass_number').val();
+
+  var variable = el.attr("id").split("_")[1];
+  var val      = el.val();
+
+  // change code
+  req = $.ajax({
+    type: "GET",
+    url:  $SCRIPT_ROOT + '/_change_article_code/' + pn,
+    data: {
+      article:  aid,
+      variable: variable,
+      value:    val //,
+//      event:    eid
+    }
+  });
+
+  req.done(function(e) {
+    $('#flash-error').hide();
+  });
+
+  req.fail(function(e) {
+    $("#flash-error").text("Error changing article text input.");
+    $("#flash-error").show();
+  });
+}
+
+/* Adds or deletes values for each variable based on radio buttons selected. */
 var storeText = function(e) {
   var el       = $(e.target);
   var aid      = $(".article").attr("id").split("_")[1];  
@@ -318,6 +395,7 @@ var storeText = function(e) {
   });
 }
 
+// DS 2020-01-16: it looks like nothing anywhere calls this?
 var getCodes = function(ev) {
   // prepopulate existing fields
   var aid = $(".article").attr("id").split("_")[1];    

--- a/templates/article-annotation-block.html
+++ b/templates/article-annotation-block.html
@@ -1,0 +1,28 @@
+<div class="article-annotation-block" id="article-annotation-block">
+  <form> 
+  <div id="debug-hook"></div>
+
+    <div class="form-group">
+      <label for="article-desc">Provide a short description of this article.</label>
+      <textarea class="form-control form-control-sm" name="article-desc" id="info_article-desc">{{ curr['article-desc']|safe }}</textarea>
+    </div>
+    
+    <div class="form-group">
+      <label>If this article was skipped, how come?</label>
+      
+      <div class="form-check">
+        <label class="form-check-label">
+          <input class="form-check-input basic-info" type="checkbox" name="date-est" id="dummy-info_date-est" value="exact" {{ 'checked' if curr['date-est'] == 'exact' else '' }} /> No protests
+        </label>
+      </div>
+
+      <div class="form-check">
+        <label class="form-check-label">
+          <input class="form-check-input basic-info" type="checkbox" name="date-est" id="dummy-info_date-est" value="approximate" {{ 'checked' if curr['date-est'] == 'approximate' else '' }} /> Protest(s), but no black protests
+        </label>
+      </div>
+
+    </div>
+
+  </form>
+</div>

--- a/templates/event-creator-block.html
+++ b/templates/event-creator-block.html
@@ -23,6 +23,9 @@
     <div class="tab-pane" id="basicinfo_block">
       <form> 
         <div class="form-group">
+          <label for="article-desc">Provide a short description of this article.</label>
+          <textarea class="form-control form-control-sm" name="article-desc" id="info_article-desc">{{ curr['article-desc']|safe }}</textarea>
+	  
           <label for="desc">Provide a short description of this event.</label>
           <textarea class="form-control form-control-sm" name="desc" id="info_desc">{{ curr['desc']|safe }}</textarea>
 	  
@@ -104,6 +107,11 @@
         <div id="list_{{ k }}" class="varlist"></div>
       </div>
       {% endfor %}
+
+      <label for="actors-freeform">Actors Freeform</label>
+      <textarea class="form-control form-control-sm" name="actors-freeform"
+		id="info_actors-freeform"
+		placeholder="e.g. Name1 / Title1 / Institution1">{{ curr['actors-freeform']|safe }}</textarea>
     </div> <!-- tab-pane --> 
 
     <div class="tab-pane" id="preset_block">

--- a/templates/event-creator-block.html
+++ b/templates/event-creator-block.html
@@ -23,9 +23,6 @@
     <div class="tab-pane" id="basicinfo_block">
       <form> 
         <div class="form-group">
-          <label for="article-desc">Provide a short description of this article.</label>
-          <textarea class="form-control form-control-sm" name="article-desc" id="info_article-desc">{{ curr['article-desc']|safe }}</textarea>
-	  
           <label for="desc">Provide a short description of this event.</label>
           <textarea class="form-control form-control-sm" name="desc" id="info_desc">{{ curr['desc']|safe }}</textarea>
 	  

--- a/templates/event-creator-block.html
+++ b/templates/event-creator-block.html
@@ -23,8 +23,6 @@
     <div class="tab-pane" id="basicinfo_block">
       <form> 
         <div class="form-group">
-          <label for="article-desc">Provide a short description of this article.</label>
-          <textarea class="form-control form-control-sm" name="article-desc" id="info_article-desc">{{ curr['article-desc']|safe }}</textarea>
 	  
           <label for="desc">Provide a short description of this event.</label>
           <textarea class="form-control form-control-sm" name="desc" id="info_desc">{{ curr['desc']|safe }}</textarea>

--- a/templates/event-creator.html
+++ b/templates/event-creator.html
@@ -20,7 +20,6 @@
           <div class="sticky">
             <input type="hidden" name="pass_number" id="pass_number" value="ec" />
             <div id="secondpassinfo">
-              <div id="article-annotation-blocks" class="varlist"></div>
               <div id="addeventblock">
                 <div class="vartitle">
                   <span>Add event</span> 

--- a/templates/event-creator.html
+++ b/templates/event-creator.html
@@ -20,6 +20,7 @@
           <div class="sticky">
             <input type="hidden" name="pass_number" id="pass_number" value="ec" />
             <div id="secondpassinfo">
+              <div id="article-annotation-blocks" class="varlist"></div>
               <div id="addeventblock">
                 <div class="vartitle">
                   <span>Add event</span> 


### PR DESCRIPTION
This one is the companion to https://github.com/MPEDS/mpeds-coder/pull/29 (and is built on top of it).  Whereas that one only enables the functionality, this one makes the minimal changes to the user-visible UI to activate it: it inserts `article-annotation-block.html` into `event-creator.html`, re-disables the display of the event-level article description in the event list panel, and removes the event-level article description field.

Like the enable PR, this one has been tested lightly on a migrated DB (though I don't think there's anything in here that our coders haven't been using for months.)

So the tl;dr version of this one is: don't accept this until https://github.com/MPEDS/mpeds-coder/pull/29 works and you actually want the coders to code article-level stuff at the article level instead of the event level (or if you prefer to activate it all some other way, just reject the PR).