### PR TITLE
Multi delete data collection

### DIFF
--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -1305,13 +1305,15 @@ def delCode(pn):
     else:
         return make_response("Invalid model", 404)
 
-    if len(a) > 0:
+    if len(a) == 0:
         for o in a:
             db_session.delete(o)
 
         db_session.commit()
 
         return jsonify(result={"status": 200})
+    elif len(a) > 1:
+        return make_response(" Leave duplicates in so we can collect data on this bug.", 500)
     else:
         return make_response("", 404)
 

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -1305,7 +1305,7 @@ def delCode(pn):
     else:
         return make_response("Invalid model", 404)
 
-    if len(a) == 0:
+    if len(a) == 1:
         for o in a:
             db_session.delete(o)
 

--- a/static/shared.js
+++ b/static/shared.js
@@ -133,7 +133,7 @@ var deleteCode = function(e) {
   });
 
   req.fail(function() {
-    $("#flash-error").text("Error deleting item.");
+    $("#flash-error").text("Error deleting item." + req.responseText);
     $("#flash-error").show();
   });
 }

--- a/static/shared.js
+++ b/static/shared.js
@@ -105,7 +105,7 @@ var addSelectedText = function(e, v) {
 }
 
 var deleteCode = function(e) {
-  var r = confirm("Are you sure you want to delete this item?");
+  var r = confirm("Are you sure you want to delete this item?\n(Note: due to bug, duplicates will not be deleted)");
   if (r == false) {
     return
   }


### PR DESCRIPTION
So @alexhanna, I recommend you accept this ASAP, but what it does is a little strange so requires attention if you haven't been following https://github.com/davidskalinder/mpeds-coder/issues/92 closely.

This PR removes coders' ability to delete duplicate entries from a single text-select variable.  This of course means that:

1. Entries that are correct but duplicated will persist as duplicated
1. Entries that are wrong and duplicated will also persist as wrong and duplicated!

So this PR will presumably create some wrong data that will need to be checked later since coders won't be able to erase some of their mistakes (if they mistakenly added something twice).  We think this is worthwhile though because we can see how many duplicates appear in order to figure out roughly how much data we've been losing due to https://github.com/davidskalinder/mpeds-coder/issues/89.

So, this should stop the bleeding of https://github.com/davidskalinder/mpeds-coder/issues/89 and enable data collection on how bad that bleeding was, but will create a new temporary problem of some fairly-easily-identifiable bad data.  The idea is to use this code for a few weeks and then override it with a permanent fix to https://github.com/davidskalinder/mpeds-coder/issues/89.

I think the changes should be pretty clear in the code, but let me know if anything's unclear, or have a look at the discussion at https://github.com/davidskalinder/mpeds-coder/issues/92, which is pretty comprehensive.