### PR TITLE
Added ordered_load function near top of controller

### DIFF
--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -24,6 +24,7 @@ from math import ceil
 from random import sample
 from random import choice
 import yaml
+from collections import OrderedDict
 
 if (sys.version_info < (3, 0)):
     import urllib2
@@ -57,6 +58,19 @@ from sqlite3 import dbapi2 as sqlite3
 from database import db_session
 from models import ArticleMetadata, ArticleQueue, CodeFirstPass, CodeSecondPass, CodeEventCreator, \
     Event, EventCreatorQueue, SecondPassQueue, User
+
+##### Enable OrderedDict with PyYAML
+##### Copy-pasta from https://stackoverflow.com/a/21912744 on 2019-12-12
+def ordered_load(stream, Loader=yaml.Loader, object_pairs_hook=OrderedDict):
+    class OrderedLoader(Loader):
+        pass
+    def construct_mapping(loader, node):
+        loader.flatten_mapping(node)
+        return object_pairs_hook(loader.construct_pairs(node))
+    OrderedLoader.add_constructor(
+        yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG,
+        construct_mapping)
+    return yaml.load(stream, OrderedLoader)
 
 # create our application
 app = Flask(__name__)


### PR DESCRIPTION
This is an ancient branch and I'm not sure why I didn't PR it before, but it adds the ability to load things from YAML files in the same order they were in the YAML, like this:

```
state_and_territory_vals = ordered_load(open(app.config['WD'] + '/states.yaml', 'r'))
```

The stuff in this PR should only add the capability though, not activate it anywhere; so you should review it, but I think it should be safe to accept.