### PR TITLE
Add pub and source fields

### DIFF
--- a/models.py
+++ b/models.py
@@ -143,21 +143,27 @@ class EventCreatorQueue(Base):
 
 class ArticleMetadata(Base):
     __tablename__ = 'article_metadata'
-    id        = Column(Integer, primary_key=True)
-    title     = Column(String(1024))
-    db_name   = Column(String(64))
-    db_id     = Column(String(255))
-    filename  = Column(String(255), nullable = False)
+    id                  = Column(Integer, primary_key=True)
+    title               = Column(String(1024))
+    db_name             = Column(String(64))
+    db_id               = Column(String(255))
+    filename            = Column(String(255), nullable = False)
+    pub_date            = Column(Date)
+    publication         = Column(String(511))
+    source_description  = Column(String(511))
 
     firsts  = relationship("CodeFirstPass",  backref = backref("article_metadata", order_by = id))
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))
     queue   = relationship("ArticleQueue",   backref = backref("article_metadata", order_by = id))
 
-    def __init__(self, filename, db_name = None, db_id = None, title = None):
-        self.filename  = filename
-        self.db_name   = db_name
-        self.db_id     = db_id
-        self.title     = title
+    def __init__(self, filename, db_name = None, db_id = None, title = None, pub_date = None, publication = None, source_description = None):
+        self.filename           = filename
+        self.db_name            = db_name
+        self.db_id              = db_id
+        self.title              = title
+        self.pub_date           = pub_date
+        self.publication        = publication
+        self.source_description = source_description
 
     def __repr__(self):
         return '<ArticleMetadata %r (%r)>' % (self.title, self.id)

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Unicode, ForeignKey, UniqueConstraint, Text
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Unicode, ForeignKey, UniqueConstraint, Text, Date
 from sqlalchemy.orm import relationship, backref
 from flask_login import UserMixin
 from database import Base


### PR DESCRIPTION
All right, this one should be pretty straightforward: it just adds some empty fields in the `article_metadata` table to hold publication date, publication, and source description for each article.

It does require a database change though.  I did this in two stages (from [here](https://github.com/davidskalinder/mpeds-coder/issues/39) and [here](https://github.com/davidskalinder/mpeds-coder/issues/76), so rather than air-code it into a single untested statement, I'll just paste the two I ran:

```
ALTER TABLE article_metadata ADD COLUMN pub_date DATE;
ALTER TABLE article_metadata ADD publication varchar(511), ADD source_description varchar(511);
```

It has been a while since I ran those, so you should probably accept this and run those statements in a testing environment first just to be sure.