### PR TITLE
Add clean solr fields

### DIFF
--- a/models.py
+++ b/models.py
@@ -157,7 +157,7 @@ class ArticleMetadata(Base):
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))
     queue   = relationship("ArticleQueue",   backref = backref("article_metadata", order_by = id))
 
-    def __init__(self, filename, db_name = None, db_id = None, title = None, pub_date = None, publication = None, source_description = None):
+    def __init__(self, filename, db_name = None, db_id = None, title = None, pub_date = None, publication = None, source_description = None, self.text = None):
         self.filename           = filename
         self.db_name            = db_name
         self.db_id              = db_id

--- a/models.py
+++ b/models.py
@@ -157,7 +157,15 @@ class ArticleMetadata(Base):
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))
     queue   = relationship("ArticleQueue",   backref = backref("article_metadata", order_by = id))
 
-    def __init__(self, filename, db_name = None, db_id = None, title = None, pub_date = None, publication = None, source_description = None, self.text = None):
+    def __init__(self,
+                 filename,
+                 db_name = None,
+                 db_id = None,
+                 title = None,
+                 pub_date = None,
+                 publication = None,
+                 source_description = None,
+                 self.text = None):
         self.filename           = filename
         self.db_name            = db_name
         self.db_id              = db_id

--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Unicode, ForeignKey, UniqueConstraint, Text
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Unicode, ForeignKey, UniqueConstraint, Text, Date
 from sqlalchemy.orm import relationship, backref
 from flask_login import UserMixin
 from database import Base
@@ -148,16 +148,18 @@ class ArticleMetadata(Base):
     db_name   = Column(String(64))
     db_id     = Column(String(255))
     filename  = Column(String(255), nullable = False)
+    pub_date  = Column(Date)
 
     firsts  = relationship("CodeFirstPass",  backref = backref("article_metadata", order_by = id))
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))
     queue   = relationship("ArticleQueue",   backref = backref("article_metadata", order_by = id))
 
-    def __init__(self, filename, db_name = None, db_id = None, title = None):
+    def __init__(self, filename, db_name = None, db_id = None, title = None, pub_date = None):
         self.filename  = filename
         self.db_name   = db_name
         self.db_id     = db_id
         self.title     = title
+        self.pub_date  = pub_date
 
     def __repr__(self):
         return '<ArticleMetadata %r (%r)>' % (self.title, self.id)

--- a/models.py
+++ b/models.py
@@ -151,7 +151,9 @@ class ArticleMetadata(Base):
     pub_date            = Column(Date)
     publication         = Column(String(511))
     source_description  = Column(String(511))
-    text                = Column(UnicodeText(16777200, collation='utf8_unicode_ci'))
+    ## FIXME: Collation arg may will break anything but MySQL 5.7
+    text                = Column(UnicodeText(4194300,
+                                 collation='utf8mb4_general_ci'))
 
     firsts  = relationship("CodeFirstPass",  backref = backref("article_metadata", order_by = id))
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))

--- a/models.py
+++ b/models.py
@@ -165,6 +165,7 @@ class ArticleMetadata(Base):
         self.pub_date           = pub_date
         self.publication        = publication
         self.source_description = source_description
+        self.text               = text
 
     def __repr__(self):
         return '<ArticleMetadata %r (%r)>' % (self.title, self.id)

--- a/models.py
+++ b/models.py
@@ -165,7 +165,7 @@ class ArticleMetadata(Base):
                  pub_date = None,
                  publication = None,
                  source_description = None,
-                 self.text = None):
+                 text = None):
         self.filename           = filename
         self.db_name            = db_name
         self.db_id              = db_id

--- a/models.py
+++ b/models.py
@@ -151,7 +151,7 @@ class ArticleMetadata(Base):
     pub_date            = Column(Date)
     publication         = Column(String(511))
     source_description  = Column(String(511))
-    text                = Column(UnicodeText(16777200))
+    text                = Column(UnicodeText(16777200, collation='utf8_unicode_ci'))
 
     firsts  = relationship("CodeFirstPass",  backref = backref("article_metadata", order_by = id))
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))


### PR DESCRIPTION
All right @alexhanna: I've deployed everything now which means cue the Ennio Morricone music because it's time for the PRs.

This one is the first step for killing Solr.  It creates the empty fields in MySQL for all stuff we want to copy over from Solr.

It requires an ALTER TABLE statement before deploying, which can be found at https://github.com/davidskalinder/mpeds-coder/issues/113#issuecomment-749763561.  Obvs remove any fields from the statement that are already in your table (MySQL should fail to run the statement and give you an error if you don't).

As long as that SQL statement has been run, this PR shouldn't cause any user-visible changes.