### PR TITLE
Enable internal article usage

### DIFF
--- a/models.py
+++ b/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Boolean, Column, DateTime, Integer, String, Unicode, ForeignKey, UniqueConstraint, Text
+from sqlalchemy import Boolean, Column, DateTime, Integer, String, Unicode, ForeignKey, UniqueConstraint, Text, Date
 from sqlalchemy.orm import relationship, backref
 from flask_login import UserMixin
 from database import Base
@@ -148,16 +148,18 @@ class ArticleMetadata(Base):
     db_name   = Column(String(64))
     db_id     = Column(String(255))
     filename  = Column(String(255), nullable = False)
+    pub_date  = Column(Date)
 
     firsts  = relationship("CodeFirstPass",  backref = backref("article_metadata", order_by = id))
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))
     queue   = relationship("ArticleQueue",   backref = backref("article_metadata", order_by = id))
 
-    def __init__(self, filename, db_name = None, db_id = None, title = None):
+    def __init__(self, filename, db_name = None, db_id = None, title = None, pub_date = None):
         self.filename  = filename
         self.db_name   = db_name
         self.db_id     = db_id
         self.title     = title
+        self.pub_date  = pub_date
 
     def __repr__(self):
         return '<ArticleMetadata %r (%r)>' % (self.title, self.id)

--- a/models.py
+++ b/models.py
@@ -165,6 +165,7 @@ class ArticleMetadata(Base):
         self.pub_date           = pub_date
         self.publication        = publication
         self.source_description = source_description
+        self.text               = text
 
     def __repr__(self):
         return '<ArticleMetadata %r (%r)>' % (self.title, self.id)

--- a/models.py
+++ b/models.py
@@ -151,7 +151,7 @@ class ArticleMetadata(Base):
     pub_date            = Column(Date)
     publication         = Column(String(511))
     source_description  = Column(String(511))
-    text                = Column(UnicodeText(16777200))
+    text                = Column(UnicodeText(16777200, collation='utf8_unicode_ci'))
 
     firsts  = relationship("CodeFirstPass",  backref = backref("article_metadata", order_by = id))
     seconds = relationship("CodeSecondPass", backref = backref("article_metadata", order_by = id))

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -182,8 +182,12 @@ def loadSolr(solr_id):
 
 ## prep any article for display
 def prepText(article):
-    fn    = article.filename
-    db_id = article.db_id
+    fn                 = article.filename
+    db_id              = article.db_id
+    atitle             = article.title
+    pub_date           = article.pub_date
+    publication        = article.publication
+    fulltext           = article.text
 
     metawords = ['DATE', 'PUBLICATION', 'LANGUAGE', 'DATELINE', 'SECTION',
     'EDITION', 'LENGTH', 'DATE', 'SEARCH_ID', 'Published', 'By', 'AP', 'UPI']
@@ -197,7 +201,11 @@ def prepText(article):
 
     filename = str('INTERNAL_ID: %s' % fn)
 
-    if app.config['SOLR'] == True:
+    if app.config['STORE_ARTICLES_INTERNALLY'] == True:
+      title = atitle
+      meta = [publication, pub_date, db_id]
+      paras = fulltext.split('<br/>')
+    elif app.config['SOLR'] == True:
         title, meta, paras = loadSolr(db_id)
         if title == 0:
             title = "Cannot find article in Solr."

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -202,9 +202,9 @@ def prepText(article):
     filename = str('INTERNAL_ID: %s' % fn)
 
     if app.config['STORE_ARTICLES_INTERNALLY'] == True:
-      title = atitle
-      meta = [publication, pub_date, db_id]
-      paras = fulltext.split('<br/>')
+        title = atitle
+        meta = [publication, pub_date, db_id]
+        paras = fulltext.split('<br/>')
     elif app.config['SOLR'] == True:
         title, meta, paras = loadSolr(db_id)
         if title == 0:

--- a/mpeds_coder.py
+++ b/mpeds_coder.py
@@ -857,7 +857,12 @@ def admin():
     pubs  = []
 
     ## get the available publications
-    if app.config['SOLR']:
+    if app.config['STORE_ARTICLES_INTERNALLY']:
+        pubquery = db_session.query(ArticleMetadata.publication).\
+                   distinct().\
+                   order_by(ArticleMetadata.publication)
+        pubs = [row.publication for row in pubquery]
+    elif app.config['SOLR']:
         url = '{}/select?q=Database:"University%20Wire"&rows=0&wt=json'.format(app.config['SOLR_ADDR'])
         fparams = 'facet=true&facet.field=PUBLICATION&facet.limit=1000'
 


### PR DESCRIPTION
This one allows the new data fetched by https://github.com/MPEDS/mpeds-coder/pull/47 and stored in the fields created by https://github.com/MPEDS/mpeds-coder/pull/46 to be used.

It requires a change to `config.py`: Before making the PR live, add `STORE_ARTICLES_INTERNALLY = True` to `config.py` (or, to keep using Solr, use `STORE_ARTICLES_INTERNALLY = False`).  MAI will choke if the value isn't there at all.

The only user-visible change is that when the config value is set to `True`, the kinda-sorta `db_id` that used to appear at the top of articles will be replaced by the real one (with the hash string and no spaces).

For further details see https://github.com/davidskalinder/mpeds-coder/issues/71.