### PR TITLE
Remove coder table button

### DIFF
--- a/templates/coder_stats.html
+++ b/templates/coder_stats.html
@@ -103,3 +103,4 @@
   </div>
 </div>
 {% endblock %}
+

--- a/templates/coder_stats.html
+++ b/templates/coder_stats.html
@@ -98,12 +98,6 @@
             </tr>   
         </table>
 
-        <h4>Coder Audit</h4>
-            <div id="coder-audit-form-group">
-            <!--<p><a href="{{ url_for('generateCoderAudit', pn='1', action='download') }}">Download first pass table</a> (tab-separated format)</p>-->
-                <p><button type="submit" class="btn btm-primary" id="generate-ec">Generate event creator coder table</button></p>
-                <div class="form-control-feedback"></div>
-            </div>
     </div>
     {% endif %}
   </div>


### PR DESCRIPTION
I think this one simply takes the export button out of the coder stats page.  Might be worth reviewing and merging this one in until the button gets fixed properly?